### PR TITLE
feat: StashAnalytics send GENERIC_CLICK events

### DIFF
--- a/Assets/Stash.Samples/Scripts/ClickTrackingExample.cs
+++ b/Assets/Stash.Samples/Scripts/ClickTrackingExample.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using Stash.Core;
+using Stash.Scripts.Core;
+
+namespace Stash.Samples
+{
+    /// <summary>
+    /// Example script demonstrating how to use Stash click event tracking
+    /// </summary>
+    public class ClickTrackingExample : MonoBehaviour
+    {
+        [Header("Configuration")]
+        [Tooltip("Your shop handle from Stash dashboard")]
+        public string shopHandle = "your-shop-handle";
+        
+        [Tooltip("Environment to use (Test for development, Production for release)")]
+        public StashEnvironment environment = StashEnvironment.Test;
+
+        [Header("UI References (Optional)")]
+        public Button shopButton;
+        public Button settingsButton;
+        public Button playButton;
+
+        void Start()
+        {
+            // Initialize Stash SDK with analytics
+            StashSDK.Initialize(shopHandle, environment);
+
+            // Add click tracking to buttons if assigned
+            if (shopButton != null)
+            {
+                shopButton.onClick.AddListener(() => OnShopButtonClick());
+            }
+
+            if (settingsButton != null)
+            {
+                settingsButton.onClick.AddListener(() => OnSettingsButtonClick());
+            }
+
+            if (playButton != null)
+            {
+                playButton.onClick.AddListener(() => OnPlayButtonClick());
+            }
+        }
+
+        // Example 1: Basic click tracking
+        void OnShopButtonClick()
+        {
+            // Track the click with just element ID and screen name
+            StashSDK.TrackClick("shop_button", "main_menu");
+
+            Debug.Log("Shop button clicked!");
+        }
+
+        // Example 2: Click tracking with custom data
+        void OnSettingsButtonClick()
+        {
+            var customData = new Dictionary<string, object>
+            {
+                { "settingsSection", "audio" },
+                { "sessionTime", Time.timeSinceLevelLoad }
+            };
+
+            StashSDK.TrackClick("settings_button", "main_menu", customData);
+
+            Debug.Log("Settings button clicked!");
+        }
+
+        // Example 3: Simple click tracking (element ID only)
+        void OnPlayButtonClick()
+        {
+            StashSDK.TrackClick("play_button");
+
+            Debug.Log("Play button clicked!");
+        }
+
+        // Example 4: Track special offer click with rich metadata
+        public void OnSpecialOfferClick(string offerId, float price)
+        {
+            var offerData = new Dictionary<string, object>
+            {
+                { "offerId", offerId },
+                { "offerPrice", price },
+                { "currency", "USD" },
+                { "discount", 0.25f }
+            };
+
+            StashSDK.TrackClick("special_offer_banner", "store_page", offerData);
+
+            Debug.Log($"Special offer {offerId} clicked!");
+        }
+
+        // Example 5: Track inventory item click
+        public void OnInventoryItemClick(int itemIndex, string itemId)
+        {
+            var itemData = new Dictionary<string, object>
+            {
+                { "itemId", itemId },
+                { "itemIndex", itemIndex },
+                { "viewMode", "grid" }
+            };
+
+            StashSDK.TrackClick("inventory_item", "inventory_screen", itemData);
+
+            Debug.Log($"Inventory item {itemId} at index {itemIndex} clicked!");
+        }
+
+        // Example 6: Track navigation between screens
+        public void OnScreenChange(string newScreen, string previousScreen)
+        {
+            var navigationData = new Dictionary<string, object>
+            {
+                { "previousScreen", previousScreen },
+                { "loadTime", Time.time }
+            };
+
+            StashSDK.TrackClick($"nav_to_{newScreen}", previousScreen, navigationData);
+
+            Debug.Log($"Navigated from {previousScreen} to {newScreen}");
+        }
+
+        // Test method that can be called from Unity Inspector or other scripts
+        [ContextMenu("Test Click Tracking")]
+        public void TestClickTracking()
+        {
+            if (!StashSDK.IsInitialized())
+            {
+                Debug.LogWarning("SDK not initialized. Initializing with test values...");
+                StashSDK.Initialize("test-shop", StashEnvironment.Test);
+            }
+
+            var testData = new Dictionary<string, object>
+            {
+                { "testParam", "testValue" },
+                { "timestamp", System.DateTime.UtcNow.ToString("o") }
+            };
+
+            StashSDK.TrackClick("test_button", "test_scene", testData);
+            Debug.Log("Test click event sent!");
+        }
+    }
+}
+

--- a/Assets/Stash.Samples/Scripts/ClickTrackingExample.cs.meta
+++ b/Assets/Stash.Samples/Scripts/ClickTrackingExample.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5a7b9c1d3e5f7a9b1c3d5e7f9a1b3c5d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+

--- a/Assets/Stash/Scripts/Core/CoroutineRunner.cs
+++ b/Assets/Stash/Scripts/Core/CoroutineRunner.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+namespace Stash.Core
+{
+    /// <summary>
+    /// Singleton MonoBehaviour for running coroutines from non-MonoBehaviour classes
+    /// </summary>
+    public class CoroutineRunner : MonoBehaviour
+    {
+        private static CoroutineRunner instance;
+
+        public static CoroutineRunner Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    GameObject go = new GameObject("StashCoroutineRunner");
+                    instance = go.AddComponent<CoroutineRunner>();
+                    DontDestroyOnLoad(go);
+                }
+                return instance;
+            }
+        }
+    }
+}
+

--- a/Assets/Stash/Scripts/Core/CoroutineRunner.cs.meta
+++ b/Assets/Stash/Scripts/Core/CoroutineRunner.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9d5e7f2a3b6c8d1e4f5a6b7c8d9e0f1a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+

--- a/Assets/Stash/Scripts/Core/StashAnalytics.cs
+++ b/Assets/Stash/Scripts/Core/StashAnalytics.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+using Stash.Scripts.Core;
+
+namespace Stash.Core
+{
+    /// <summary>
+    /// Analytics and event tracking for Stash SDK
+    /// </summary>
+    public class StashAnalytics
+    {
+        private readonly string shopHandle;
+        private readonly string eventEndpoint;
+
+        public StashAnalytics(string shopHandle, StashEnvironment environment)
+        {
+            this.shopHandle = shopHandle;
+            this.eventEndpoint = GetEventEndpoint(environment);
+        }
+
+        private string GetEventEndpoint(StashEnvironment environment)
+        {
+            switch (environment)
+            {
+                case StashEnvironment.Production:
+                    return "https://api.stash.gg/sdk/event/log_event";
+                case StashEnvironment.Test:
+                    return "https://test-api.stash.gg/sdk/event/log_event";
+                default:
+                    return "https://test-api.stash.gg/sdk/event/log_event";
+            }
+        }
+
+        /// <summary>
+        /// Track a generic click event with device and build information
+        /// </summary>
+        /// <param name="elementId">ID of the clicked element (required)</param>
+        /// <param name="screenName">Name of the current screen (optional)</param>
+        /// <param name="additionalParams">Additional custom parameters (optional)</param>
+        public IEnumerator TrackClickEvent(
+            string elementId,
+            string screenName = null,
+            Dictionary<string, object> additionalParams = null)
+        {
+            if (string.IsNullOrEmpty(elementId))
+            {
+                Debug.LogWarning("[Stash Analytics] elementId is required");
+                yield break;
+            }
+
+            var eventData = BuildClickEventData(elementId, screenName, additionalParams);
+            yield return SendEvent("GENERIC_CLICK", eventData);  // Event type: GENERIC_CLICK
+        }
+
+        private Dictionary<string, object> BuildClickEventData(
+            string elementId,
+            string screenName,
+            Dictionary<string, object> additionalParams)
+        {
+            var eventData = new Dictionary<string, object>
+            {
+                // Event identification
+                { "clickId", Guid.NewGuid().ToString() },
+                { "elementId", elementId },
+
+                // Device information
+                { "deviceModel", SystemInfo.deviceModel },
+                { "deviceType", SystemInfo.deviceType.ToString() },
+                { "operatingSystem", SystemInfo.operatingSystem },
+                { "platform", Application.platform.ToString() },
+
+                // Build information
+                { "gameBuildVersion", Application.version },
+                { "unityVersion", Application.unityVersion },
+
+                // Timestamp
+                { "clientTimestamp", DateTime.UtcNow.ToString("o") }
+            };
+
+            // Add screen name if provided
+            if (!string.IsNullOrEmpty(screenName))
+            {
+                eventData["screenName"] = screenName;
+            }
+
+            // Merge additional parameters
+            if (additionalParams != null)
+            {
+                foreach (var kvp in additionalParams)
+                {
+                    if (!eventData.ContainsKey(kvp.Key))
+                    {
+                        eventData[kvp.Key] = kvp.Value;
+                    }
+                }
+            }
+
+            return eventData;
+        }
+
+        private IEnumerator SendEvent(string eventName, Dictionary<string, object> eventParams)
+        {
+            // Build request body matching SDK event API structure
+            // POST /sdk/event/log_event
+            var requestBody = new EventRequest
+            {
+                shopHandle = this.shopHandle,
+                eventData = new EventData
+                {
+                    name = eventName,  // e.g., "GENERIC_CLICK"
+                    parameters = ConvertDictionaryToJson(eventParams)
+                }
+            };
+
+            string jsonData = JsonUtility.ToJson(requestBody);
+            
+            // Replace "parameters" with "params" and "eventData" with "event" in JSON
+            jsonData = jsonData.Replace("\"eventData\":", "\"event\":");
+            jsonData = jsonData.Replace("\"parameters\":", "\"params\":");
+
+            using (UnityWebRequest request = UnityWebRequest.Post(eventEndpoint, ""))
+            {
+                byte[] bodyRaw = System.Text.Encoding.UTF8.GetBytes(jsonData);
+                request.uploadHandler = new UploadHandlerRaw(bodyRaw);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                request.SetRequestHeader("Content-Type", "application/json");
+
+                yield return request.SendWebRequest();
+
+                if (request.result != UnityWebRequest.Result.Success)
+                {
+                    Debug.LogError($"[Stash Analytics] Failed to send event: {request.error}");
+                }
+                else
+                {
+                    Debug.Log($"[Stash Analytics] Event '{eventName}' sent successfully");
+                }
+            }
+        }
+
+        private string ConvertDictionaryToJson(Dictionary<string, object> dict)
+        {
+            var items = new List<string>();
+            foreach (var kvp in dict)
+            {
+                string value;
+                if (kvp.Value is string)
+                {
+                    value = $"\"{EscapeJson(kvp.Value.ToString())}\"";
+                }
+                else if (kvp.Value is bool)
+                {
+                    value = kvp.Value.ToString().ToLower();
+                }
+                else if (kvp.Value == null)
+                {
+                    value = "null";
+                }
+                else
+                {
+                    value = kvp.Value.ToString();
+                }
+                items.Add($"\"{kvp.Key}\":{value}");
+            }
+            return "{" + string.Join(",", items) + "}";
+        }
+
+        private string EscapeJson(string str)
+        {
+            return str.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+        }
+
+        [Serializable]
+        private class EventRequest
+        {
+            public string shopHandle;
+            public EventData eventData;
+        }
+
+        [Serializable]
+        private class EventData
+        {
+            public string name;
+            public string parameters;
+        }
+    }
+}
+

--- a/Assets/Stash/Scripts/Core/StashAnalytics.cs.meta
+++ b/Assets/Stash/Scripts/Core/StashAnalytics.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7c3e8f1a2b4d5e6f7a8b9c0d1e2f3a4b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+

--- a/Assets/Stash/Scripts/Core/StashSDK.cs
+++ b/Assets/Stash/Scripts/Core/StashSDK.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Stash.Scripts.Core;
+
+namespace Stash.Core
+{
+    /// <summary>
+    /// Main SDK class for Stash integration
+    /// Provides initialization and analytics tracking functionality
+    /// </summary>
+    public static class StashSDK
+    {
+        private static StashAnalytics analytics;
+        private static string currentShopHandle;
+        private static StashEnvironment currentEnvironment;
+        private static bool isInitialized = false;
+
+        /// <summary>
+        /// Initialize the Stash SDK with analytics support
+        /// </summary>
+        /// <param name="shopHandle">Your shop handle</param>
+        /// <param name="environment">Environment (Production or Test)</param>
+        public static void Initialize(string shopHandle, StashEnvironment environment = StashEnvironment.Production)
+        {
+            if (string.IsNullOrEmpty(shopHandle))
+            {
+                Debug.LogError("[Stash SDK] Shop handle cannot be null or empty");
+                return;
+            }
+
+            currentShopHandle = shopHandle;
+            currentEnvironment = environment;
+
+            // Initialize analytics
+            analytics = new StashAnalytics(shopHandle, environment);
+            isInitialized = true;
+
+            Debug.Log($"[Stash SDK] Initialized with shop handle: {shopHandle}, environment: {environment}");
+        }
+
+        /// <summary>
+        /// Track a click event with optional custom data
+        /// </summary>
+        /// <param name="elementId">Identifier of the clicked element (required)</param>
+        /// <param name="screenName">Name of the current screen (optional)</param>
+        /// <param name="customData">Additional custom parameters (optional)</param>
+        public static void TrackClick(
+            string elementId,
+            string screenName = null,
+            Dictionary<string, object> customData = null)
+        {
+            if (!isInitialized || analytics == null)
+            {
+                Debug.LogError("[Stash SDK] Not initialized. Call StashSDK.Initialize() first.");
+                return;
+            }
+
+            CoroutineRunner.Instance.StartCoroutine(
+                analytics.TrackClickEvent(elementId, screenName, customData)
+            );
+        }
+
+        /// <summary>
+        /// Get the current shop handle
+        /// </summary>
+        public static string GetShopHandle()
+        {
+            return currentShopHandle;
+        }
+
+        /// <summary>
+        /// Get the current environment
+        /// </summary>
+        public static StashEnvironment GetEnvironment()
+        {
+            return currentEnvironment;
+        }
+
+        /// <summary>
+        /// Check if the SDK is initialized
+        /// </summary>
+        public static bool IsInitialized()
+        {
+            return isInitialized;
+        }
+    }
+}
+

--- a/Assets/Stash/Scripts/Core/StashSDK.cs.meta
+++ b/Assets/Stash/Scripts/Core/StashSDK.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stash SDK for Unity ![buildtest](https://github.com/stashgg/stash-unity/actions/workflows/main.yml/badge.svg)
 
-This package is designed to get your Unity project up and running with the Stash web shop in just a few steps. The package is lightweight and wraps Stash API endpoints without any external dependencies. 
+This package is designed to get your Unity project up and running with the Stash web shop in just a few steps. The package is lightweight and wraps Stash API endpoints without any external dependencies.
 
 To get started, you need to import the latest package from the [releases](https://github.com/stashgg/stash-unity/releases) section and follow our [Unity guide](https://docs.stash.gg/docs/configure-unity-project).
 
@@ -8,17 +8,35 @@ To get started, you need to import the latest package from the [releases](https:
 
 The Stash package always targets the latest LTS version of Unity. We recommend you use the LTS version of Unity to build projects that are in production or about to ship. However, you should not encounter any issues when integrating or migrating into any other versions of Unity above the targeted release.
 
-
 ## Components
 
 All components are optional, you can mix and match based on your needs.
 
-| Component     | Description                                                                 |
-|---------------|-----------------------------------------------------------------------------|
-| Stash.Core    | Provides core functionalities and API wrappers for Stash.                   |
-| [Stash.Popup](https://github.com/stashgg/stash-unity/tree/main/Assets/Stash.Popup)   | Offers a customizable card-style popup for Stash Pay.                       |
-| Stash.Samples | Includes sample scene using the Stash SDK.                 |
+| Component                                                                          | Description                                                           |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Stash.Core                                                                         | Provides core functionalities, API wrappers, and analytics for Stash. |
+| [Stash.Popup](https://github.com/stashgg/stash-unity/tree/main/Assets/Stash.Popup) | Offers a customizable card-style popup for Stash Pay.                 |
+| Stash.Samples                                                                      | Includes sample scene using the Stash SDK.                            |
 
+### Event Tracking
+
+Track user interactions and behavior in your game with built-in analytics:
+
+```csharp
+// Initialize SDK with analytics
+StashSDK.Initialize("your-shop-handle", StashEnvironment.Production);
+
+// Track click events
+StashSDK.TrackClick("shop_button", "main_menu");
+
+// Track with custom data
+var customData = new Dictionary<string, object>
+{
+    { "itemId", "premium_pack" },
+    { "price", 9.99f }
+};
+StashSDK.TrackClick("purchase_button", "store", customData);
+```
 
 ## Installation
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->

> [!NOTE]
> Adds analytics click tracking (GENERIC_CLICK) with `StashAnalytics` and `StashSDK`, a coroutine runner, a sample usage script, and README documentation.
>
> - **Core**:
>     - `StashAnalytics`: send `GENERIC_CLICK` events to `/sdk/event/log_event` (env-aware endpoints), including device/build metadata and optional params; manual JSON payload shaping.
>     - `CoroutineRunner`: singleton `MonoBehaviour` to run coroutines from non-MonoBehaviour code.
>     - `StashSDK`: initialization and `TrackClick` API plus getters and init check, delegating to `StashAnalytics` via `CoroutineRunner`.
> - **Samples**:
>     - `Stash.Samples/ClickTrackingExample`: demonstrates initialization and multiple click-tracking scenarios (basic, custom data, navigation, etc.).
> - **Docs**:
>     - `README.md`: adds Event Tracking usage examples and updates components table to include analytics.
>
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ee143a6e657d32307b253be5ac5aec2620b5175. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

<!-- /CURSOR_SUMMARY -->