### PR TITLE
Dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,6 @@
 #   - secrets.APPSTORE_PRIVATE_KEY
 #   - secrets.APPSTORE_KEY_ID
 #   - secrets.APPSTORE_ISSUER_ID
-# Android Build Notes:
-# 
 
 name: Build Unity Project
 
@@ -804,16 +802,19 @@ jobs:
       - name: Create latest build archive
         if: matrix.platform != 'Android' && matrix.platform != 'iOS'
         run: |
-          cd build/${{ matrix.platform }}
-          zip -r ${{ github.workspace }}/build/${{ matrix.platform }}-latest.zip .
           cd ${{ github.workspace }}
-          echo "Created archive: build/${{ matrix.platform }}-latest.zip"
+          ZIP_FILE="${{ github.workspace }}/${{ matrix.platform }}-latest.zip"
+          cd build/${{ matrix.platform }}
+          zip -r "$ZIP_FILE" . -q
+          cd ${{ github.workspace }}
+          echo "Created archive: $ZIP_FILE"
+          ls -lh "$ZIP_FILE"
       
       - name: Upload latest build archive to GCS
         if: matrix.platform != 'Android' && matrix.platform != 'iOS'
         uses: google-github-actions/upload-cloud-storage@v3
         with:
-          path: build/${{ matrix.platform }}-latest.zip
+          path: ${{ github.workspace }}/${{ matrix.platform }}-latest.zip
           destination: stash_sdk_demo/${{ matrix.platform }}/latest/${{ matrix.platform }}-latest.zip
           parent: false
           gzip: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -747,7 +747,7 @@ jobs:
       
       # iOS: Upload to TestFlight using Apple's recommended action
       - name: Upload to TestFlight
-        if: matrix.platform == 'iOS' && github.event_name == 'workflow_dispatch' && inputs.upload_to_testflight == true
+        if: matrix.platform == 'iOS' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.upload_to_testflight == true))
         uses: apple-actions/upload-testflight-build@v1
         with:
           app-path: 'build/iOS/iOS/export/StashDemo.ipa'
@@ -786,18 +786,14 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v3
         with:
           path: ${{ env.APK_FILE }}
-          destination: stash_sdk_demo/Android/latest/StashDemo.apk
-          parent: false
-          gzip: false
+          destination: stash_sdk_demo/Android/latest/
       
       - name: Upload latest iOS IPA to GCS
         if: matrix.platform == 'iOS'
         uses: google-github-actions/upload-cloud-storage@v3
         with:
           path: build/iOS/iOS/export/StashDemo.ipa
-          destination: stash_sdk_demo/iOS/latest/StashDemo.ipa
-          parent: false
-          gzip: false
+          destination: stash_sdk_demo/iOS/latest/
       
       - name: Create latest build archive
         if: matrix.platform != 'Android' && matrix.platform != 'iOS'
@@ -815,9 +811,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v3
         with:
           path: ${{ github.workspace }}/${{ matrix.platform }}-latest.zip
-          destination: stash_sdk_demo/${{ matrix.platform }}/latest/${{ matrix.platform }}-latest.zip
-          parent: false
-          gzip: false
+          destination: stash_sdk_demo/${{ matrix.platform }}/latest/
 
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands iOS TestFlight upload to run on push, switches GCS uploads to directory targets, and refines archive creation/upload paths.
> 
> - **CI (GitHub Actions ` .github/workflows/main.yml`)**:
>   - **TestFlight**: Broaden `Upload to TestFlight` condition to run on `push` (and `workflow_dispatch` with opt-in).
>   - **GCS uploads**:
>     - Android/iOS artifacts now uploaded to directory destinations (`stash_sdk_demo/Android/latest/`, `stash_sdk_demo/iOS/latest/`).
>     - Generic platform archives uploaded to `stash_sdk_demo/${{ matrix.platform }}/latest/` using workspace-generated zip path.
>   - **Archiving**: Create latest build zip using `$GITHUB_WORKSPACE`, store as `${platform}-latest.zip`, quiet zip output, and log file details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aba0835f49f018ae06d3c38721b5555363e14b7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->