### PR TITLE
Dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ on:
           - StandaloneWindows64
           - Android
           - iOS
+          - StandaloneOSX
       upload_to_testflight:
         description: 'Upload to TestFlight (iOS only)'
         required: false
@@ -40,7 +41,7 @@ jobs:
       - id: set-platforms
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
-            echo 'platforms=["Android","iOS","StandaloneWindows64"]' >> $GITHUB_OUTPUT
+            echo 'platforms=["Android","iOS","StandaloneWindows64","StandaloneOSX"]' >> $GITHUB_OUTPUT
           else
             echo "platforms=[\"${{ inputs.platform }}\"]" >> $GITHUB_OUTPUT
           fi
@@ -48,7 +49,7 @@ jobs:
   build:
     name: Build for ${{ matrix.platform }}
     needs: determine-platforms
-    runs-on: ${{ matrix.platform == 'iOS' && 'macos-latest' || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.platform == 'iOS' || matrix.platform == 'StandaloneOSX') && 'macos-latest' || 'ubuntu-latest' }}
     strategy:
       matrix:
         platform: ${{ fromJSON(needs.determine-platforms.outputs.platforms) }}
@@ -259,7 +260,7 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           targetPlatform: ${{ matrix.platform }}
-          buildName: ${{ matrix.platform == 'iOS' && 'iOS' || matrix.platform }}
+          buildName: ${{ matrix.platform == 'iOS' && 'iOS' || (matrix.platform == 'StandaloneOSX' && 'macOS' || matrix.platform) }}
           androidExportType: ${{ matrix.platform == 'Android' && 'androidPackage' || '' }}
           androidKeystoreName: ${{ matrix.platform == 'Android' && 'user.keystore' || '' }}
           androidKeystoreBase64: ${{ matrix.platform == 'Android' && secrets.ANDROID_KEYSTORE_BASE64 || '' }}
@@ -812,6 +813,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/${{ matrix.platform }}-latest.zip
           destination: stash_sdk_demo/${{ matrix.platform }}/latest/
+
 
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -787,14 +787,20 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v3
         with:
           path: ${{ env.APK_FILE }}
-          destination: stash_sdk_demo/Android/latest/
+          destination: stash_sdk_demo/Android/latest/StashDemo.apk
+          parent: false
+          gzip: false
+          process_gcloudignore: false
       
       - name: Upload latest iOS IPA to GCS
         if: matrix.platform == 'iOS'
         uses: google-github-actions/upload-cloud-storage@v3
         with:
           path: build/iOS/iOS/export/StashDemo.ipa
-          destination: stash_sdk_demo/iOS/latest/
+          destination: stash_sdk_demo/iOS/latest/StashDemo.ipa
+          parent: false
+          gzip: false
+          process_gcloudignore: false
       
       - name: Create latest build archive
         if: matrix.platform != 'Android' && matrix.platform != 'iOS'
@@ -812,7 +818,10 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v3
         with:
           path: ${{ github.workspace }}/${{ matrix.platform }}-latest.zip
-          destination: stash_sdk_demo/${{ matrix.platform }}/latest/
+          destination: stash_sdk_demo/${{ matrix.platform }}/latest/${{ matrix.platform }}-latest.zip
+          parent: false
+          gzip: false
+          process_gcloudignore: false
 
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds StandaloneOSX to the build matrix, uses macOS runners for iOS/macOS, maps macOS build name, and updates GCS uploads to fixed filenames with explicit options.
> 
> - **CI Workflow (`.github/workflows/main.yml`)**:
>   - **Platform support**:
>     - Add `StandaloneOSX` to `workflow_dispatch` choices and default push matrix.
>     - Use `macos-latest` runner for `iOS` and `StandaloneOSX` builds.
>   - **Unity build**:
>     - Map `buildName` to `macOS` when `matrix.platform` is `StandaloneOSX`.
>   - **Artifact uploads to GCS**:
>     - Android/iOS: upload to fixed filenames (`stash_sdk_demo/Android/latest/StashDemo.apk`, `stash_sdk_demo/iOS/latest/StashDemo.ipa`).
>     - Other platforms: upload zipped archive to `stash_sdk_demo/${{ matrix.platform }}/latest/${{ matrix.platform }}-latest.zip`.
>     - Set `parent: false`, `gzip: false`, `process_gcloudignore: false` for uploads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef494ecbe22cc4b84afe49f12dd9e759f4aeaa0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->