### PR TITLE
Update Git URL path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ All components are optional. Mix and match based on your needs.
 
 1. Open **Window > Package Manager**
 2. Click **+** → **Add package from git URL**
-3. Enter: `https://github.com/stashgg/stash-unity.git?path=Assets/Stash`
+3. Enter: `https://github.com/stashgg/stash-unity.git?path=Assets`
 
 ## Documentation
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the README Git URL to use `?path=Assets` instead of `?path=Assets/Stash` for Package Manager installation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74ce2b5d14c45214af8a3afab82af46167f976fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->