### PR TITLE
iOS Popup Implementation Improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -274,8 +274,30 @@ jobs:
           git update-index --assume-unchanged ProjectSettings/ProjectSettings.asset
           echo "✅ Told git to ignore changes to ProjectSettings.asset"
       
-      # Build Unity project
+      
+      # Build Unity project (with retry on failure)
       - name: Build Unity project
+        id: unity-build
+        continue-on-error: true
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          targetPlatform: ${{ (matrix.platform == 'iOS' || matrix.platform == 'iOS-simulator') && 'iOS' || matrix.platform }}
+          buildName: ${{ matrix.platform == 'iOS' && 'iOS' || (matrix.platform == 'iOS-simulator' && 'iOS-simulator' || (matrix.platform == 'StandaloneOSX' && 'macOS' || matrix.platform)) }}
+          androidExportType: ${{ matrix.platform == 'Android' && 'androidPackage' || '' }}
+          androidKeystoreName: ${{ matrix.platform == 'Android' && 'user.keystore' || '' }}
+          androidKeystoreBase64: ${{ matrix.platform == 'Android' && secrets.ANDROID_KEYSTORE_BASE64 || '' }}
+          androidKeystorePass: ${{ matrix.platform == 'Android' && secrets.ANDROID_KEYSTORE_PASS || '' }}
+          androidKeyaliasName: ${{ matrix.platform == 'Android' && secrets.ANDROID_KEYALIAS_NAME || '' }}
+          androidKeyaliasPass: ${{ matrix.platform == 'Android' && secrets.ANDROID_KEYALIAS_PASS || '' }}
+      
+      # Retry Unity build if first attempt failed
+      # Unity sometimes fails to build if too many builds in matrix are triggered at once with the same license.
+      - name: Retry Unity build (If first attempt failed)
+        if: steps.unity-build.outcome == 'failure'
         uses: game-ci/unity-builder@v4
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/Assets/Stash.Popup/Plugins/Android/StashPayCardPlugin.java
+++ b/Assets/Stash.Popup/Plugins/Android/StashPayCardPlugin.java
@@ -334,7 +334,10 @@ public class StashPayCardPlugin {
                 isCurrentlyPresented = false;
             });
             
-        isCurrentlyPresented = true;
+            // Show dialog immediately
+            currentDialog.show();
+            animateFadeIn();
+            isCurrentlyPresented = true;
         } catch (Exception e) {
             Log.e(TAG, "Error creating popup: " + e.getMessage());
         }
@@ -731,25 +734,11 @@ public class StashPayCardPlugin {
                 
                 injectStashSDKFunctions();
                 
-                // Show the dialog now that the page has finished loading
-                if (currentDialog != null && !currentDialog.isShowing()) {
-                    activity.runOnUiThread(() -> {
-                        try {
-                            currentDialog.show();
-                            animateFadeIn();
-                            view.setVisibility(View.VISIBLE);
-                            hideLoadingIndicator();
-                        } catch (Exception e) {
-                            android.util.Log.e(TAG, "Error showing dialog after page load: " + e.getMessage());
-                        }
-                    });
-                } else {
-                    // Dialog already showing, just make WebView visible
-                    view.postDelayed(() -> {
-                        hideLoadingIndicator();
-                        view.setVisibility(View.VISIBLE);
-                    }, 300);
-                }
+                // Show webview and hide loading indicator
+                view.postDelayed(() -> {
+                    hideLoadingIndicator();
+                    view.setVisibility(View.VISIBLE);
+                }, 300);
             }
         });
         


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors iOS popup/card presentation and gestures (iPhone slide-up, iPad centered, improved loading/scroll, cleanup), updates Android popup to show immediately with fade-in, and adds a retry step to Unity CI builds.
> 
> - **iOS (StashPayCardURLHandler.mm)**:
>   - **Presentation/Animation**: Use window-based presentation; iPhone card slides up from offscreen; iPad/popup centered with refined corner masking and overlay.
>   - **Gestures**: Rework drag tray behavior—iPad allows only downward drags to dismiss; improved snap-back/dismiss thresholds; keyboard expand/collapse only on iPhone.
>   - **Loading/Display**: Show webview when ready (or on commit for iPhone); on error, show after brief delay; popup loading view fades in with container.
>   - **Scrolling/CSS**: Enable scrolling for popup; inject CSS to prevent overscroll; remove prior forced scroll disabling; consistent handle via tagged view.
>   - **Cleanup/State**: More thorough teardown of delegates/associated objects; safer single-callback handling.
> - **Android (StashPayCardPlugin.java)**:
>   - Show popup dialog immediately with fade-in; simplify page-finished handler to reveal webview and hide loading after delay.
> - **CI (GitHub Actions)**:
>   - Add retry-on-failure for Unity build step (continue-on-error + conditional retry).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00d03aa97d3820f4fd1d1e68ea412b3dc8fe7f47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->