### PR TITLE
Document forcePortrait Option for Landscape-Locked Games

### DIFF
--- a/Assets/Stash.Native/Sample/Scripts/StashSample.cs
+++ b/Assets/Stash.Native/Sample/Scripts/StashSample.cs
@@ -32,6 +32,7 @@ public class StashSample : MonoBehaviour
         // config.tabletHeightRatioPortrait = 0.45f;
         // config.tabletWidthRatioLandscape = 0.25f;
         // config.tabletHeightRatioLandscape = 0.5f;
+        // If your game is locked to landscape, uncomment this to force portrait for checkout:
         // config.forcePortrait = true;
 
         StashNative.Instance.OpenCard(TEST_URL,
@@ -90,6 +91,8 @@ public class StashSample : MonoBehaviour
             {
                 // Open the returned URL in the native card.
                 var config = StashNativeCardConfig.Default;
+                // If your game is locked to landscape, uncomment this to force portrait for checkout:
+                // config.forcePortrait = true;
                 StashNative.Instance.OpenCard(url,
                     () => SetStatus("Dismissed"),
                     () => SetStatus("Success"),

--- a/README.md
+++ b/README.md
@@ -72,11 +72,16 @@ public class MyStore : MonoBehaviour
 {
     void PurchaseItem(string checkoutUrl)
     {
+        var config = StashNativeCardConfig.Default;
+        // If your game is locked to landscape orientation, force portrait for checkout:
+        // config.forcePortrait = true;
+        
         StashNative.Instance.OpenCard(
             STASH_URL_TO_OPEN,
             dismissCallback: OnDialogDismissed,
             successCallback: OnPaymentSuccess,
-            failureCallback: OnPaymentFailure
+            failureCallback: OnPaymentFailure,
+            config: config
         );
     }
 
@@ -85,6 +90,8 @@ public class MyStore : MonoBehaviour
     void OnPaymentFailure() => ShowErrorMessage("Payment could not be processed");
 }
 ```
+
+**Note for landscape-locked games:** If your Unity game is locked to landscape orientation (`defaultScreenOrientation: 4`), set `config.forcePortrait = true` to ensure checkout displays in portrait mode. Portrait orientation must be enabled in Unity Player Settings (iOS: `allowedAutorotateToPortrait: 1`) for this to work.
 
 All callbacks and config are optional; you can pass only the ones you need or use the global events instead. See the API reference below for more details about configuration options.
 
@@ -176,7 +183,7 @@ Optional per-call config for **`OpenCard`**. **`StashNativeCardConfig.Default`**
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| **`forcePortrait`** | `false` | Portrait-locked on phone when true. |
+| **`forcePortrait`** | `false` | Portrait-locked on phone when true. **Required for landscape-locked games:** Set to `true` if your Unity game is locked to landscape orientation to ensure checkout displays in portrait. Portrait orientation must be enabled in Unity Player Settings (iOS: `allowedAutorotateToPortrait: 1`). |
 | **`cardHeightRatioPortrait`** | `0.68f` | Card height ratio portrait (0.1–1.0). |
 | **`cardWidthRatioLandscape`** | `0.9f` | Card width ratio landscape. |
 | **`cardHeightRatioLandscape`** | `0.6f` | Card height ratio landscape. |


### PR DESCRIPTION
# Document forcePortrait Option for Landscape-Locked Games

## Overview

This PR adds documentation and sample code comments to guide partners on using the existing `forcePortrait` option when their Unity games are locked to landscape orientation. This ensures checkout is always usable by displaying in portrait mode, even when the game itself is locked to landscape.

## Problem

When a Unity game is locked to landscape orientation (`defaultScreenOrientation: 4`), the Stash checkout would also display in landscape mode, making it difficult or impossible for users to complete purchases. The checkout UI is designed for portrait orientation and doesn't work well in landscape.

## Solution

The StashNative SDK already supports forcing portrait orientation via the `forcePortrait` flag in `StashNativeCardConfig`. This PR documents when and how partners should use this existing feature.

## Changes

### Documentation (`README.md`)
- Added guidance in the `OpenCard()` example showing how to use `forcePortrait` when game is locked to landscape
- Added a note explaining the requirement for landscape-locked games
- Updated the `forcePortrait` field description in the API reference to clarify when it's needed
- Clarified that portrait orientation must be enabled in Unity Player Settings (iOS: `allowedAutorotateToPortrait: 1`)

### Sample Code (`StashSample.cs`)
- Added helpful comments in `OpenCard()` method explaining when to uncomment `forcePortrait = true`
- Added the same guidance in `GenerateLinkAndOpen()` method
- Kept `forcePortrait` commented out by default (partners enable it if needed)

## Requirements

- **iOS**: Portrait orientation must be enabled in Unity Player Settings (`allowedAutorotateToPortrait: 1` in `ProjectSettings.asset`)
- **Android**: No additional configuration needed
- Game can remain locked to landscape (`defaultScreenOrientation: 4`)

## Usage

Partners with landscape-locked games should:

```var config = StashNativeCardConfig.Default;
config.forcePortrait = true; // Force portrait for checkout

StashNative.Instance.OpenCard(checkoutUrl, 
    onDismiss: OnDismissed,
    onSuccess: OnSuccess,
    onFailure: OnFailure,
    config: config
);```
