### PR TITLE
Update lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-# Lint - strict C# formatting. No Unity or .sln required; lints all C# under Assets directly (--folder).
+# Lint - strict C# formatting. No Unity or .sln required; lints C# under the UPM package (--folder).
 
 name: Lint
 
@@ -22,8 +22,14 @@ jobs:
         with:
           dotnet-version: "8.0.x"
 
-      - name: Verify C# whitespace (all .cs under Assets, no solution)
-        run: dotnet format whitespace Assets --folder --verify-no-changes --verbosity minimal
+      - name: Verify C# whitespace (UPM package and Assets if present)
+        run: |
+          if [ -d Packages/gg.stash.unity ]; then
+            dotnet format whitespace Packages/gg.stash.unity --folder --verify-no-changes --verbosity minimal
+          fi
+          if [ -d Assets ]; then
+            dotnet format whitespace Assets --folder --verify-no-changes --verbosity minimal
+          fi
         env:
           DOTNET_NOLOGO: true
 
@@ -38,7 +44,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y shellcheck
           shopt -s globstar nullglob
-          for f in Assets/**/*.sh .github/**/*.sh; do
+          for f in Assets/**/*.sh Packages/**/*.sh .github/**/*.sh; do
             [ -f "$f" ] && shellcheck -x "$f" || true
           done
         continue-on-error: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change; it broadens lint coverage and adds directory-existence guards, with the main risk being unexpected CI failures if formatting or shellcheck issues exist in the newly included paths.
> 
> **Overview**
> Updates the GitHub Actions `Lint` workflow to run `dotnet format whitespace` against the UPM package (`Packages/gg.stash.unity`) and optionally `Assets` when those directories exist.
> 
> Expands ShellCheck scanning to include `Packages/**/*.sh` in addition to existing `Assets` and `.github` scripts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0728d3838a7fbb1c04976ee682ac521db8eaf472. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->