### PR TITLE
Poll payment status after external browser closes so games get succes…

### DIFF
--- a/Packages/gg.stash.unity/CHANGELOG.md
+++ b/Packages/gg.stash.unity/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [2.2.5] - 2026-06-26
+
+### Added
+
+- **External browser payments (Android / iOS):** when checkout opens an external browser (e.g. Google Pay via `openExternalBrowser`), the Unity wrapper now tracks checkout context and **polls payment status after `OnBrowserClosed`** — firing `OnPaymentSuccess` / `OnPaymentFailure` without requiring a return deeplink. Supports legacy Adyen checkout (`order_result` + `complete_purchase`) and multi-PSP (`/v1/multipsp/.../status` + `/v1/multipsp/complete`). Session-scoped dedupe by `paymentId` prevents duplicate callbacks.
+
 ## [2.2.4] - 2026-06-24
 
 ### Changed

--- a/Packages/gg.stash.unity/Runtime/StashCheckoutUrlParser.cs
+++ b/Packages/gg.stash.unity/Runtime/StashCheckoutUrlParser.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Stash.Native
+{
+    internal enum StashCheckoutPaymentFlow
+    {
+        Unknown,
+        AdyenLegacy,
+        MultiPsp
+    }
+
+    internal sealed class StashCheckoutContext
+    {
+        public string CheckoutLinkId;
+        public string ShopHandle;
+        public string PaymentId;
+        public string LegacyPaymentIntentId;
+        public string ApiBaseUrl;
+        public string CheckoutPageUrl;
+        public StashCheckoutPaymentFlow Flow = StashCheckoutPaymentFlow.Unknown;
+        public bool ExternalPaymentInProgress;
+    }
+
+    internal static class StashCheckoutUrlParser
+    {
+        private static readonly Regex PayOrderPath =
+            new Regex(@"/pay/(?!success|failed|confirming|authorizing|channel-selection)([^/?#]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex LegacyOrderPath =
+            new Regex(@"/order/([^/?#]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex PaymentIntentPath =
+            new Regex(@"/pay/(?:success|failed|confirming)/([^/?#]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public static StashCheckoutContext Parse(string url)
+        {
+            var context = new StashCheckoutContext();
+            if (string.IsNullOrWhiteSpace(url))
+                return context;
+
+            if (!Uri.TryCreate(NormalizeUrl(url), UriKind.Absolute, out var uri))
+                return context;
+
+            context.CheckoutPageUrl = uri.GetLeftPart(UriPartial.Path);
+            context.ApiBaseUrl = ResolveApiBaseUrl(uri);
+            context.ShopHandle = ParseShopHandle(uri);
+            context.CheckoutLinkId = ParseCheckoutLinkId(uri);
+            context.PaymentId = ParseQueryValue(uri, "paymentId");
+            context.LegacyPaymentIntentId = ParsePaymentIntentId(uri);
+
+            if (string.IsNullOrEmpty(context.PaymentId))
+                context.PaymentId = context.LegacyPaymentIntentId;
+
+            return context;
+        }
+
+        public static StashCheckoutContext Merge(StashCheckoutContext primary, StashCheckoutContext secondary)
+        {
+            if (primary == null) return secondary ?? new StashCheckoutContext();
+            if (secondary == null) return primary;
+
+            if (string.IsNullOrEmpty(primary.CheckoutLinkId))
+                primary.CheckoutLinkId = secondary.CheckoutLinkId;
+            if (string.IsNullOrEmpty(primary.ShopHandle))
+                primary.ShopHandle = secondary.ShopHandle;
+            if (string.IsNullOrEmpty(primary.PaymentId))
+                primary.PaymentId = secondary.PaymentId;
+            if (string.IsNullOrEmpty(primary.LegacyPaymentIntentId))
+                primary.LegacyPaymentIntentId = secondary.LegacyPaymentIntentId;
+            if (string.IsNullOrEmpty(primary.ApiBaseUrl))
+                primary.ApiBaseUrl = secondary.ApiBaseUrl;
+            if (string.IsNullOrEmpty(primary.CheckoutPageUrl))
+                primary.CheckoutPageUrl = secondary.CheckoutPageUrl;
+            if (primary.Flow == StashCheckoutPaymentFlow.Unknown)
+                primary.Flow = secondary.Flow;
+
+            return primary;
+        }
+
+        public static string NormalizeUrl(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+                return url;
+            if (!url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+                !url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                return "https://" + url;
+            return url;
+        }
+
+        private static string ParseCheckoutLinkId(Uri uri)
+        {
+            var path = uri.AbsolutePath ?? "";
+            var payMatch = PayOrderPath.Match(path);
+            if (payMatch.Success)
+                return payMatch.Groups[1].Value;
+
+            var legacyMatch = LegacyOrderPath.Match(path);
+            if (legacyMatch.Success)
+                return legacyMatch.Groups[1].Value;
+
+            return null;
+        }
+
+        private static string ParsePaymentIntentId(Uri uri)
+        {
+            var fromPath = PaymentIntentPath.Match(uri.AbsolutePath ?? "");
+            if (fromPath.Success)
+                return fromPath.Groups[1].Value;
+
+            return ParseQueryValue(uri, "paymentIntentId");
+        }
+
+        private static string ParseShopHandle(Uri uri)
+        {
+            var fromQuery = ParseQueryValue(uri, "shopHandle");
+            if (!string.IsNullOrEmpty(fromQuery))
+                return fromQuery;
+
+            var host = uri.Host ?? "";
+            if (host.Equals("checkout.stash.gg", StringComparison.OrdinalIgnoreCase) ||
+                host.Equals("checkout.stashstaging.com", StringComparison.OrdinalIgnoreCase) ||
+                host.Equals("test.stashpreview.com", StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            const string stagingSuffix = ".stashstaging.com";
+            const string prodSuffix = ".stash.gg";
+            const string previewSuffix = ".stashpreview.com";
+
+            if (host.EndsWith(stagingSuffix, StringComparison.OrdinalIgnoreCase))
+                return host.Substring(0, host.Length - stagingSuffix.Length);
+            if (host.EndsWith(prodSuffix, StringComparison.OrdinalIgnoreCase))
+                return host.Substring(0, host.Length - prodSuffix.Length);
+            if (host.EndsWith(previewSuffix, StringComparison.OrdinalIgnoreCase))
+                return host.Substring(0, host.Length - previewSuffix.Length);
+
+            return null;
+        }
+
+        private static string ParseQueryValue(Uri uri, string key)
+        {
+            if (uri == null || string.IsNullOrEmpty(key))
+                return null;
+
+            var query = uri.Query;
+            if (string.IsNullOrEmpty(query))
+                return null;
+
+            foreach (var part in query.TrimStart('?').Split('&'))
+            {
+                if (string.IsNullOrEmpty(part))
+                    continue;
+                var eq = part.IndexOf('=');
+                var name = eq >= 0 ? part.Substring(0, eq) : part;
+                if (!name.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                var value = eq >= 0 ? part.Substring(eq + 1) : "";
+                return Uri.UnescapeDataString(value.Replace('+', ' '));
+            }
+
+            return null;
+        }
+
+        private static string ResolveApiBaseUrl(Uri checkoutUri)
+        {
+            var host = checkoutUri.Host ?? "";
+            if (host.Contains("stashstaging", StringComparison.OrdinalIgnoreCase) ||
+                host.Contains("stashpreview", StringComparison.OrdinalIgnoreCase))
+                return "https://test-api.stashstaging.com";
+
+            return "https://api.stash.gg";
+        }
+    }
+}

--- a/Packages/gg.stash.unity/Runtime/StashExternalPaymentResolver.cs
+++ b/Packages/gg.stash.unity/Runtime/StashExternalPaymentResolver.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Stash.Native
+{
+    internal sealed class StashExternalPaymentResolver
+    {
+        private const string DeviceIdPlayerPrefsKey = "stash-device-id";
+
+        private readonly StashNative _host;
+        private readonly HashSet<string> _handledPaymentIds = new HashSet<string>(StringComparer.Ordinal);
+
+        private StashCheckoutContext _sessionContext = new StashCheckoutContext();
+        private Coroutine _pollCoroutine;
+        private bool _resolutionCompleted;
+
+        public StashExternalPaymentResolver(StashNative host)
+        {
+            _host = host;
+        }
+
+        public void BeginCheckoutSession(string checkoutUrl)
+        {
+            CancelPolling();
+            _sessionContext = StashCheckoutUrlParser.Parse(checkoutUrl);
+            _sessionContext.ExternalPaymentInProgress = false;
+            _host.StartCoroutine(PrefetchOrderSummary(_sessionContext));
+        }
+
+        public void OnExternalPayment(string externalUrl)
+        {
+            var parsed = StashCheckoutUrlParser.Parse(externalUrl);
+            _sessionContext = StashCheckoutUrlParser.Merge(_sessionContext, parsed);
+            _sessionContext.ExternalPaymentInProgress = true;
+            _host.StartCoroutine(PrefetchOrderSummary(_sessionContext));
+        }
+
+        public void OnBrowserClosed()
+        {
+            if (!_sessionContext.ExternalPaymentInProgress)
+                return;
+
+            _sessionContext.ExternalPaymentInProgress = false;
+            CancelPolling();
+            _resolutionCompleted = false;
+            _pollCoroutine = _host.StartCoroutine(PollUntilTerminal());
+        }
+
+        public void ResetSession()
+        {
+            CancelPolling();
+            _sessionContext = new StashCheckoutContext();
+        }
+
+        public bool TryMarkPaymentHandled(string paymentId)
+        {
+            if (string.IsNullOrEmpty(paymentId))
+                return false;
+            return _handledPaymentIds.Add(paymentId);
+        }
+
+        public void NotePaymentHandledFromNative(string orderPayload)
+        {
+            var paymentId = TryExtractPaymentId(orderPayload);
+            if (!string.IsNullOrEmpty(paymentId))
+                _handledPaymentIds.Add(paymentId);
+        }
+
+        private static string TryExtractPaymentId(string orderPayload)
+        {
+            if (string.IsNullOrEmpty(orderPayload))
+                return null;
+
+            const string marker = "\"paymentId\"";
+            var index = orderPayload.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+            if (index < 0)
+                return null;
+
+            var colon = orderPayload.IndexOf(':', index + marker.Length);
+            if (colon < 0)
+                return null;
+
+            var startQuote = orderPayload.IndexOf('"', colon + 1);
+            if (startQuote < 0)
+                return null;
+            var endQuote = orderPayload.IndexOf('"', startQuote + 1);
+            if (endQuote <= startQuote)
+                return null;
+
+            return orderPayload.Substring(startQuote + 1, endQuote - startQuote - 1);
+        }
+
+        private void CancelPolling()
+        {
+            if (_pollCoroutine != null)
+            {
+                _host.StopCoroutine(_pollCoroutine);
+                _pollCoroutine = null;
+            }
+        }
+
+        private IEnumerator PrefetchOrderSummary(StashCheckoutContext context)
+        {
+            if (string.IsNullOrEmpty(context.CheckoutLinkId) || string.IsNullOrEmpty(context.ApiBaseUrl))
+                yield break;
+
+            var headers = BuildRequestHeaders(context.CheckoutPageUrl);
+            OrderSummaryV2Payload summary = null;
+            string error = null;
+
+            yield return StashPaymentApiClient.FetchOrderSummaryV2(
+                context.ApiBaseUrl,
+                context.CheckoutLinkId,
+                headers,
+                payload => summary = payload,
+                err => error = err);
+
+            if (summary == null)
+            {
+                if (!string.IsNullOrEmpty(error))
+                    Debug.LogWarning("[StashNative] Failed to prefetch order summary for external payment: " + error);
+                yield break;
+            }
+
+            if (!string.IsNullOrEmpty(summary.shopHandle))
+                context.ShopHandle = summary.shopHandle;
+
+            if (summary.multiPspPaymentFlow != null && !string.IsNullOrEmpty(summary.multiPspPaymentFlow.sessionId))
+                context.Flow = StashCheckoutPaymentFlow.MultiPsp;
+            else if (summary.adyenAdvancedFlow != null && !string.IsNullOrEmpty(summary.adyenAdvancedFlow.id))
+            {
+                context.Flow = StashCheckoutPaymentFlow.AdyenLegacy;
+                context.LegacyPaymentIntentId = summary.adyenAdvancedFlow.id;
+                if (string.IsNullOrEmpty(context.PaymentId))
+                    context.PaymentId = summary.adyenAdvancedFlow.id;
+            }
+        }
+
+        private IEnumerator PollUntilTerminal()
+        {
+            var context = _sessionContext;
+            if (string.IsNullOrEmpty(context.ApiBaseUrl))
+            {
+                FireFailure();
+                yield break;
+            }
+
+            if (context.Flow == StashCheckoutPaymentFlow.MultiPsp &&
+                !string.IsNullOrEmpty(context.CheckoutLinkId) &&
+                !string.IsNullOrEmpty(context.PaymentId))
+            {
+                yield return PollMultiPsp(context);
+                yield break;
+            }
+
+            if (!string.IsNullOrEmpty(context.LegacyPaymentIntentId))
+            {
+                context.Flow = StashCheckoutPaymentFlow.AdyenLegacy;
+                yield return PollLegacyAdyen(context);
+                yield break;
+            }
+
+            if (!string.IsNullOrEmpty(context.CheckoutLinkId))
+            {
+                yield return PrefetchOrderSummary(context);
+                if (context.Flow == StashCheckoutPaymentFlow.MultiPsp &&
+                    !string.IsNullOrEmpty(context.PaymentId))
+                {
+                    yield return PollMultiPsp(context);
+                    yield break;
+                }
+
+                if (!string.IsNullOrEmpty(context.LegacyPaymentIntentId))
+                {
+                    yield return PollLegacyAdyen(context);
+                    yield break;
+                }
+            }
+
+            Debug.LogWarning("[StashNative] External payment browser closed but checkout context was incomplete; treating as failure.");
+            FireFailure();
+        }
+
+        private IEnumerator PollLegacyAdyen(StashCheckoutContext context)
+        {
+            var paymentIntentId = context.LegacyPaymentIntentId;
+            var headers = BuildRequestHeaders(context.CheckoutPageUrl);
+            var startedAt = Time.realtimeSinceStartup;
+
+            while (Time.realtimeSinceStartup - startedAt < StashPaymentApiClient.MaxPollDurationSeconds)
+            {
+                LegacyOrderResultPayload result = null;
+                string error = null;
+                yield return StashPaymentApiClient.GetLegacyOrderResult(
+                    context.ApiBaseUrl,
+                    paymentIntentId,
+                    headers,
+                    payload => result = payload,
+                    err => error = err);
+
+                if (result?.resultStatus != null)
+                {
+                    var status = result.resultStatus.status ?? "";
+                    if (status.Equals("SUCCEEDED", StringComparison.OrdinalIgnoreCase))
+                    {
+                        yield return CompleteLegacyAndFire(context, paymentIntentId, headers);
+                        yield break;
+                    }
+
+                    if (status.Equals("CANCELED", StringComparison.OrdinalIgnoreCase))
+                    {
+                        FireFailure(paymentIntentId);
+                        yield break;
+                    }
+                }
+                else if (!string.IsNullOrEmpty(error))
+                {
+                    Debug.LogWarning("[StashNative] Legacy order result poll failed: " + error);
+                }
+
+                yield return new WaitForSecondsRealtime(StashPaymentApiClient.PollIntervalSeconds);
+            }
+
+            FireFailure(paymentIntentId);
+        }
+
+        private IEnumerator CompleteLegacyAndFire(
+            StashCheckoutContext context,
+            string paymentIntentId,
+            StashRequestHeaders headers)
+        {
+            CompletePurchasePayload complete = null;
+            string error = null;
+            yield return StashPaymentApiClient.CompleteLegacyPurchase(
+                context.ApiBaseUrl,
+                paymentIntentId,
+                context.ShopHandle,
+                headers,
+                payload => complete = payload,
+                err => error = err);
+
+            if (complete != null &&
+                (complete.status ?? "").Equals("SUCCEEDED", StringComparison.OrdinalIgnoreCase))
+            {
+                FireSuccess(paymentIntentId);
+                yield break;
+            }
+
+            if (!string.IsNullOrEmpty(error))
+                Debug.LogWarning("[StashNative] Legacy complete purchase failed: " + error);
+
+            FireFailure(paymentIntentId);
+        }
+
+        private IEnumerator PollMultiPsp(StashCheckoutContext context)
+        {
+            var paymentId = context.PaymentId;
+            var headers = BuildRequestHeaders(context.CheckoutPageUrl);
+            var startedAt = Time.realtimeSinceStartup;
+            var completeTriggered = false;
+
+            while (Time.realtimeSinceStartup - startedAt < StashPaymentApiClient.MaxPollDurationSeconds)
+            {
+                MultiPspPaymentStatusPayload statusPayload = null;
+                string error = null;
+                yield return StashPaymentApiClient.GetMultiPspPaymentStatus(
+                    context.ApiBaseUrl,
+                    context.CheckoutLinkId,
+                    paymentId,
+                    headers,
+                    payload => statusPayload = payload,
+                    err => error = err);
+
+                var status = statusPayload?.status ?? "";
+                if (IsMultiPspFailureStatus(status))
+                {
+                    FireFailure(paymentId);
+                    yield break;
+                }
+
+                if (IsMultiPspSuccessStatus(status))
+                {
+                    if (!completeTriggered &&
+                        status.Equals("PAYMENT_STATUS_AUTHORIZATION_SUCCEEDED", StringComparison.Ordinal))
+                    {
+                        completeTriggered = true;
+                        CompletePurchasePayload complete = null;
+                        string completeError = null;
+                        yield return StashPaymentApiClient.CompleteMultiPspCheckout(
+                            context.ApiBaseUrl,
+                            paymentId,
+                            email: null,
+                            headers,
+                            payload => complete = payload,
+                            err => completeError = err);
+
+                        if (complete != null &&
+                            (complete.status ?? "").Equals("SUCCEEDED", StringComparison.OrdinalIgnoreCase))
+                        {
+                            FireSuccess(paymentId);
+                            yield break;
+                        }
+
+                        if (!string.IsNullOrEmpty(completeError))
+                            Debug.LogWarning("[StashNative] Multi-PSP complete failed: " + completeError);
+
+                        FireFailure(paymentId);
+                        yield break;
+                    }
+
+                    FireSuccess(paymentId);
+                    yield break;
+                }
+
+                if (!string.IsNullOrEmpty(error))
+                    Debug.LogWarning("[StashNative] Multi-PSP status poll failed: " + error);
+
+                yield return new WaitForSecondsRealtime(StashPaymentApiClient.PollIntervalSeconds);
+            }
+
+            FireFailure(paymentId);
+        }
+
+        private static bool IsMultiPspSuccessStatus(string status)
+        {
+            return status.Equals("PAYMENT_STATUS_AUTHORIZATION_SUCCEEDED", StringComparison.Ordinal) ||
+                   status.Equals("PAYMENT_STATUS_CAPTURE_SUCCEEDED", StringComparison.Ordinal);
+        }
+
+        private static bool IsMultiPspFailureStatus(string status)
+        {
+            return status.Equals("PAYMENT_STATUS_AUTHORIZATION_FAILED", StringComparison.Ordinal) ||
+                   status.Equals("PAYMENT_STATUS_CAPTURE_FAILED", StringComparison.Ordinal);
+        }
+
+        private void FireSuccess(string paymentId)
+        {
+            if (_resolutionCompleted)
+                return;
+            if (!string.IsNullOrEmpty(paymentId) && !TryMarkPaymentHandled(paymentId))
+                return;
+
+            _resolutionCompleted = true;
+            var payload = string.IsNullOrEmpty(paymentId) ? "" : $"{{\"paymentId\":\"{EscapeJson(paymentId)}\"}}";
+            _host.DispatchPaymentSuccess(payload);
+        }
+
+        private void FireFailure(string paymentId = null)
+        {
+            if (_resolutionCompleted)
+                return;
+            if (!string.IsNullOrEmpty(paymentId) && !TryMarkPaymentHandled(paymentId))
+                return;
+
+            _resolutionCompleted = true;
+            _host.DispatchPaymentFailure();
+        }
+
+        private static string EscapeJson(string value)
+        {
+            return (value ?? "").Replace("\\", "\\\\").Replace("\"", "\\\"");
+        }
+
+        private static StashRequestHeaders BuildRequestHeaders(string checkoutPageUrl)
+        {
+            var headers = new StashRequestHeaders
+            {
+                DeviceId = GetOrCreateDeviceId()
+            };
+
+#if UNITY_ANDROID && !UNITY_EDITOR
+            if (!string.IsNullOrEmpty(checkoutPageUrl))
+            {
+                try
+                {
+                    using (var cookieManager = new AndroidJavaClass("android.webkit.CookieManager"))
+                    {
+                        var instance = cookieManager.CallStatic<AndroidJavaObject>("getInstance");
+                        var cookies = instance.Call<string>("getCookie", checkoutPageUrl);
+                        if (!string.IsNullOrEmpty(cookies))
+                            headers.Cookie = cookies;
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning("[StashNative] Failed to read checkout cookies: " + e.Message);
+                }
+            }
+#endif
+            return headers;
+        }
+
+        private static string GetOrCreateDeviceId()
+        {
+            var existing = PlayerPrefs.GetString(DeviceIdPlayerPrefsKey, "");
+            if (!string.IsNullOrEmpty(existing))
+                return existing;
+
+            var deviceId = Guid.NewGuid().ToString();
+            PlayerPrefs.SetString(DeviceIdPlayerPrefsKey, deviceId);
+            PlayerPrefs.Save();
+            return deviceId;
+        }
+    }
+}

--- a/Packages/gg.stash.unity/Runtime/StashNative.cs
+++ b/Packages/gg.stash.unity/Runtime/StashNative.cs
@@ -153,6 +153,27 @@ namespace Stash.Native
         private Action<string> _currentSuccessCallback;
         private Action _currentFailureCallback;
 
+        private StashExternalPaymentResolver _externalPaymentResolver;
+
+        private void EnsureExternalPaymentResolver()
+        {
+            if (_externalPaymentResolver == null)
+                _externalPaymentResolver = new StashExternalPaymentResolver(this);
+        }
+
+        internal void DispatchPaymentSuccess(string orderPayload)
+        {
+            var o = orderPayload ?? "";
+            _currentSuccessCallback?.Invoke(o);
+            OnPaymentSuccess?.Invoke(o);
+        }
+
+        internal void DispatchPaymentFailure()
+        {
+            _currentFailureCallback?.Invoke();
+            OnPaymentFailure?.Invoke();
+        }
+
         #endregion
 
         #region Native Plugin
@@ -191,16 +212,32 @@ namespace Stash.Native
 
         public void OnAndroidPaymentSuccess(string order)
         {
+            EnsureExternalPaymentResolver();
+            _externalPaymentResolver.NotePaymentHandledFromNative(order);
             var o = order ?? "";
             _currentSuccessCallback?.Invoke(o);
             OnPaymentSuccess?.Invoke(o);
         }
 
         public void OnAndroidPaymentFailure(string message) { _currentFailureCallback?.Invoke(); OnPaymentFailure?.Invoke(); }
-        public void OnAndroidDialogDismissed(string message) { _currentDismissCallback?.Invoke(); OnDialogDismissed?.Invoke(); _currentDismissCallback = null; _currentSuccessCallback = null; _currentFailureCallback = null; }
+        public void OnAndroidDialogDismissed(string message)
+        {
+            EnsureExternalPaymentResolver();
+            _externalPaymentResolver.ResetSession();
+            _currentDismissCallback?.Invoke();
+            OnDialogDismissed?.Invoke();
+            _currentDismissCallback = null;
+            _currentSuccessCallback = null;
+            _currentFailureCallback = null;
+        }
         public void OnAndroidOptinResponse(string optinType) => OnOptinResponse?.Invoke(optinType ?? "");
         public void OnAndroidNetworkError(string message) => OnNetworkError?.Invoke();
-        public void OnAndroidExternalPayment(string url) => OnExternalPayment?.Invoke(url ?? "");
+        public void OnAndroidExternalPayment(string url)
+        {
+            EnsureExternalPaymentResolver();
+            _externalPaymentResolver.OnExternalPayment(url ?? "");
+            OnExternalPayment?.Invoke(url ?? "");
+        }
 
         public void OnAndroidPageLoaded(string loadTimeMs)
         {
@@ -208,7 +245,12 @@ namespace Stash.Native
                 OnPageLoaded?.Invoke(loadTime);
         }
 
-        public void OnAndroidBrowserClosed(string message) => OnBrowserClosed?.Invoke();
+        public void OnAndroidBrowserClosed(string message)
+        {
+            EnsureExternalPaymentResolver();
+            _externalPaymentResolver.OnBrowserClosed();
+            OnBrowserClosed?.Invoke();
+        }
 
 #elif UNITY_IOS && !UNITY_EDITOR
         [DllImport("__Internal")] private static extern bool _StashNativeCardBridgeIsSDKAvailable();
@@ -225,17 +267,38 @@ namespace Stash.Native
 
         public void OnIOSPaymentSuccess(string order)
         {
+            EnsureExternalPaymentResolver();
+            _externalPaymentResolver.NotePaymentHandledFromNative(order);
             var o = order ?? "";
             _currentSuccessCallback?.Invoke(o);
             OnPaymentSuccess?.Invoke(o);
         }
 
         public void OnIOSPaymentFailure() { _currentFailureCallback?.Invoke(); OnPaymentFailure?.Invoke(); }
-        public void OnIOSDialogDismissed() { _currentDismissCallback?.Invoke(); OnDialogDismissed?.Invoke(); _currentDismissCallback = null; _currentSuccessCallback = null; _currentFailureCallback = null; }
+        public void OnIOSDialogDismissed()
+        {
+            EnsureExternalPaymentResolver();
+            _externalPaymentResolver.ResetSession();
+            _currentDismissCallback?.Invoke();
+            OnDialogDismissed?.Invoke();
+            _currentDismissCallback = null;
+            _currentSuccessCallback = null;
+            _currentFailureCallback = null;
+        }
         public void OnIOSOptinResponse(string optinType) => OnOptinResponse?.Invoke(optinType ?? "");
         public void OnIOSNetworkError() => OnNetworkError?.Invoke();
-        public void OnIOSExternalPayment(string url) => OnExternalPayment?.Invoke(url ?? "");
-        public void OnIOSBrowserClosed() => OnBrowserClosed?.Invoke();
+        public void OnIOSExternalPayment(string url)
+        {
+            EnsureExternalPaymentResolver();
+            _externalPaymentResolver.OnExternalPayment(url ?? "");
+            OnExternalPayment?.Invoke(url ?? "");
+        }
+        public void OnIOSBrowserClosed()
+        {
+            EnsureExternalPaymentResolver();
+            _externalPaymentResolver.OnBrowserClosed();
+            OnBrowserClosed?.Invoke();
+        }
         public void OnIOSPageLoaded(string loadTimeMsStr)
         {
             if (double.TryParse(loadTimeMsStr, out double loadTime))
@@ -408,6 +471,9 @@ namespace Stash.Native
             _currentSuccessCallback = successCallback;
             _currentFailureCallback = failureCallback;
 
+            EnsureExternalPaymentResolver();
+            _externalPaymentResolver.BeginCheckoutSession(url);
+
 #if UNITY_ANDROID && !UNITY_EDITOR
             InitializeAndroidPlugin();
             if (androidPluginInstance != null)
@@ -516,7 +582,16 @@ namespace Stash.Native
 
         public void OnEditorPaymentFailure() { _currentFailureCallback?.Invoke(); OnPaymentFailure?.Invoke(); }
         public void OnEditorOptinResponse(string optinType) => OnOptinResponse?.Invoke(optinType ?? "");
-        public void OnEditorDismissCatalog() { _currentDismissCallback?.Invoke(); OnDialogDismissed?.Invoke(); _currentDismissCallback = null; _currentSuccessCallback = null; _currentFailureCallback = null; }
+        public void OnEditorDismissCatalog()
+        {
+            EnsureExternalPaymentResolver();
+            _externalPaymentResolver.ResetSession();
+            _currentDismissCallback?.Invoke();
+            OnDialogDismissed?.Invoke();
+            _currentDismissCallback = null;
+            _currentSuccessCallback = null;
+            _currentFailureCallback = null;
+        }
 
         private void OpenEditorTestWindow(string url, bool isModal)
         {

--- a/Packages/gg.stash.unity/Runtime/StashPaymentApiClient.cs
+++ b/Packages/gg.stash.unity/Runtime/StashPaymentApiClient.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections;
+using System.Text;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Stash.Native
+{
+    internal static class StashPaymentApiClient
+    {
+        public const float PollIntervalSeconds = 2f;
+        public const float MaxPollDurationSeconds = 300f;
+
+        public static IEnumerator FetchOrderSummaryV2(
+            string apiBaseUrl,
+            string checkoutLinkId,
+            StashRequestHeaders headers,
+            Action<OrderSummaryV2Payload> onSuccess,
+            Action<string> onError)
+        {
+            var url = $"{apiBaseUrl.TrimEnd('/')}/api/checkout_links/order/{Uri.EscapeDataString(checkoutLinkId)}/get_v2";
+            yield return GetJson(url, headers, body =>
+            {
+                var payload = JsonUtility.FromJson<OrderSummaryV2Payload>(body);
+                if (payload == null)
+                {
+                    onError?.Invoke("Failed to parse order summary.");
+                    return;
+                }
+                onSuccess?.Invoke(payload);
+            }, onError);
+        }
+
+        public static IEnumerator GetLegacyOrderResult(
+            string apiBaseUrl,
+            string paymentIntentId,
+            StashRequestHeaders headers,
+            Action<LegacyOrderResultPayload> onSuccess,
+            Action<string> onError)
+        {
+            var url = $"{apiBaseUrl.TrimEnd('/')}/api/checkout_links/order_result/{Uri.EscapeDataString(paymentIntentId)}";
+            yield return GetJson(url, headers, body =>
+            {
+                var payload = JsonUtility.FromJson<LegacyOrderResultPayload>(body);
+                if (payload?.resultStatus == null)
+                {
+                    onError?.Invoke("Failed to parse order result.");
+                    return;
+                }
+                onSuccess?.Invoke(payload);
+            }, onError);
+        }
+
+        public static IEnumerator CompleteLegacyPurchase(
+            string apiBaseUrl,
+            string paymentIntentId,
+            string shopHandle,
+            StashRequestHeaders headers,
+            Action<CompletePurchasePayload> onSuccess,
+            Action<string> onError)
+        {
+            var url = $"{apiBaseUrl.TrimEnd('/')}/api/checkout_links/complete_purchase/{Uri.EscapeDataString(paymentIntentId)}";
+            var body = JsonUtility.ToJson(new CompletePurchaseRequest { shopHandle = shopHandle ?? "" });
+            yield return PostJson(url, body, headers, responseBody =>
+            {
+                var payload = JsonUtility.FromJson<CompletePurchasePayload>(responseBody);
+                onSuccess?.Invoke(payload ?? new CompletePurchasePayload());
+            }, onError);
+        }
+
+        public static IEnumerator GetMultiPspPaymentStatus(
+            string apiBaseUrl,
+            string checkoutLinkId,
+            string paymentId,
+            StashRequestHeaders headers,
+            Action<MultiPspPaymentStatusPayload> onSuccess,
+            Action<string> onError)
+        {
+            var url =
+                $"{apiBaseUrl.TrimEnd('/')}/v1/multipsp/checkout-links/{Uri.EscapeDataString(checkoutLinkId)}/payments/{Uri.EscapeDataString(paymentId)}/status";
+            yield return GetJson(url, headers, body =>
+            {
+                var payload = JsonUtility.FromJson<MultiPspPaymentStatusPayload>(body);
+                onSuccess?.Invoke(payload ?? new MultiPspPaymentStatusPayload());
+            }, onError);
+        }
+
+        public static IEnumerator CompleteMultiPspCheckout(
+            string apiBaseUrl,
+            string paymentId,
+            string email,
+            StashRequestHeaders headers,
+            Action<CompletePurchasePayload> onSuccess,
+            Action<string> onError)
+        {
+            var url = $"{apiBaseUrl.TrimEnd('/')}/v1/multipsp/complete";
+            var body = JsonUtility.ToJson(new CompleteMultiPspRequest
+            {
+                paymentId = paymentId ?? "",
+                email = email ?? ""
+            });
+            yield return PostJson(url, body, headers, responseBody =>
+            {
+                var payload = JsonUtility.FromJson<CompletePurchasePayload>(responseBody);
+                onSuccess?.Invoke(payload ?? new CompletePurchasePayload());
+            }, onError);
+        }
+
+        private static IEnumerator GetJson(
+            string url,
+            StashRequestHeaders headers,
+            Action<string> onSuccess,
+            Action<string> onError)
+        {
+            using (var request = UnityWebRequest.Get(url))
+            {
+                ApplyHeaders(request, headers);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                yield return request.SendWebRequest();
+
+                if (request.result != UnityWebRequest.Result.Success)
+                {
+                    onError?.Invoke(request.error ?? $"HTTP {request.responseCode}");
+                    yield break;
+                }
+
+                onSuccess?.Invoke(request.downloadHandler.text ?? "");
+            }
+        }
+
+        private static IEnumerator PostJson(
+            string url,
+            string jsonBody,
+            StashRequestHeaders headers,
+            Action<string> onSuccess,
+            Action<string> onError)
+        {
+            var bodyBytes = Encoding.UTF8.GetBytes(jsonBody ?? "{}");
+            using (var request = new UnityWebRequest(url, "POST"))
+            {
+                request.uploadHandler = new UploadHandlerRaw(bodyBytes);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                request.SetRequestHeader("Content-Type", "application/json");
+                ApplyHeaders(request, headers);
+                yield return request.SendWebRequest();
+
+                if (request.result != UnityWebRequest.Result.Success)
+                {
+                    onError?.Invoke(request.error ?? $"HTTP {request.responseCode}");
+                    yield break;
+                }
+
+                onSuccess?.Invoke(request.downloadHandler.text ?? "");
+            }
+        }
+
+        private static void ApplyHeaders(UnityWebRequest request, StashRequestHeaders headers)
+        {
+            if (headers == null)
+                return;
+            if (!string.IsNullOrEmpty(headers.DeviceId))
+                request.SetRequestHeader("x-stash-did", headers.DeviceId);
+            if (!string.IsNullOrEmpty(headers.Authorization))
+                request.SetRequestHeader("Authorization", headers.Authorization);
+            if (!string.IsNullOrEmpty(headers.Cookie))
+                request.SetRequestHeader("Cookie", headers.Cookie);
+        }
+    }
+
+    internal sealed class StashRequestHeaders
+    {
+        public string DeviceId;
+        public string Authorization;
+        public string Cookie;
+    }
+
+    [Serializable]
+    internal sealed class OrderSummaryV2Payload
+    {
+        public string shopHandle;
+        public AdyenAdvancedFlowPayload adyenAdvancedFlow;
+        public MultiPspPaymentFlowPayload multiPspPaymentFlow;
+    }
+
+    [Serializable]
+    internal sealed class AdyenAdvancedFlowPayload
+    {
+        public string id;
+    }
+
+    [Serializable]
+    internal sealed class MultiPspPaymentFlowPayload
+    {
+        public string sessionId;
+    }
+
+    [Serializable]
+    internal sealed class LegacyOrderResultPayload
+    {
+        public LegacyOrderResultStatusPayload resultStatus;
+    }
+
+    [Serializable]
+    internal sealed class LegacyOrderResultStatusPayload
+    {
+        public string status;
+    }
+
+    [Serializable]
+    internal sealed class MultiPspPaymentStatusPayload
+    {
+        public string status;
+    }
+
+    [Serializable]
+    internal sealed class CompletePurchasePayload
+    {
+        public string status;
+    }
+
+    [Serializable]
+    internal sealed class CompletePurchaseRequest
+    {
+        public string shopHandle;
+    }
+
+    [Serializable]
+    internal sealed class CompleteMultiPspRequest
+    {
+        public string paymentId;
+        public string email;
+    }
+}

--- a/Packages/gg.stash.unity/package.json
+++ b/Packages/gg.stash.unity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gg.stash.unity",
   "displayName": "Stash for Unity",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "unity": "2021.3",
   "unityRelease": "0f1",
   "description": "Native-feeling Stash Pay IAP checkout and webshop presentation directly inside your Unity game (Android/iOS).",


### PR DESCRIPTION
…s/failure without a deeplink.

Google Pay and similar flows open Chrome Custom Tabs via openExternalBrowser; the embedded webview never receives onPaymentSuccess. Track checkout context, poll legacy Adyen and multi-PSP APIs on OnBrowserClosed, and dedupe callbacks by paymentId.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stashgg/codesmith/stash-unity/pr/25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785097116&installation_id=136649696&pr_number=25&repository=stashgg%2Fstash-unity&return_to=https%3A%2F%2Fgithub.com%2Fstashgg%2Fstash-unity%2Fpull%2F25&signature=a7b45857dc1c1d887c705927ea424a43ef7d4ef6c44f629ec5b5103084be033e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how purchases complete for external-browser flows by calling checkout APIs and firing success/failure; mis-polling or incomplete context could grant or deny entitlements incorrectly, though dedupe and native path coordination reduce duplicate callbacks.
> 
> **Overview**
> **External browser checkout (Android/iOS)** no longer depends on a deeplink to finish IAP when the user pays in Chrome Custom Tabs / Safari (e.g. Google Pay via `openExternalBrowser`). The wrapper **tracks checkout context** from the opened URL and external-payment URLs, then **polls after `OnBrowserClosed`** until the payment is terminal.
> 
> New internal pieces: **`StashCheckoutUrlParser`** (checkout link id, shop handle, payment ids, API host), **`StashPaymentApiClient`** (order summary, legacy Adyen `order_result` + `complete_purchase`, multi-PSP status + `/v1/multipsp/complete`), and **`StashExternalPaymentResolver`** (prefetch flow type, poll up to 5 minutes, Android checkout cookies + `x-stash-did`). **`StashNative`** hooks these at card/modal open, `OnExternalPayment`, browser close, and dialog dismiss; **`DispatchPaymentSuccess` / `DispatchPaymentFailure`** centralize callbacks. **Session `paymentId` dedupe** avoids double success/failure when native already reported the payment.
> 
> Public API unchanged; package version **2.2.5** and changelog updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 200c1fc6cbfbf43b9f84cc395ece8f5426e4552f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->